### PR TITLE
migrates to modern coroutine syntax.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 env:
   - PATH=$HOME/protobuf/bin:$PATH
 before_install:

--- a/README.en.md
+++ b/README.en.md
@@ -5,7 +5,7 @@ It supports RPC calling via 'sofa-bolt + protobuf' protocol.
 
 ## requirements
 
-- python3 >= 3.4 (aio classes needs asyncio support)
+- python3 >= 3.5 (aio classes needs asyncio support)
 - python2.7 (limited support, needs extra 3rd party libraries)
 - mosn >= 1.3 (to use with version >= 0.6)
 - mosn < 1.3 (to use with version < 0.6)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ anthunder是一个python实现的BOLT协议库，提供BOLT client和server功�
 
 ## requirements
 
-- python3 >= 3.4 (aio classes needs asyncio support)
+- python3 >= 3.5 (aio classes needs asyncio support)
 - python2.7 (limited support, needs extra 3rd party libraries)
 - mosn >= 1.3 (to use with version >= 0.6)
 - mosn < 1.3 (to use with version < 0.6)

--- a/performance_aio.py
+++ b/performance_aio.py
@@ -45,12 +45,11 @@ class Counter(object):
     def inc(self):
         self.count += 1
 
-    @asyncio.coroutine
-    def print_count(self):
+    async def print_count(self):
         secs = 0
         last_count = 0
         while True:
-            yield from asyncio.sleep(1)
+            await asyncio.sleep(1)
             secs += 1
             curr_count = self.count
             print("{} secs: {} requests: {} r/s".format(secs, curr_count, (curr_count - last_count)))
@@ -67,8 +66,7 @@ class CoroExecutor(object):
     def submit(self, func, *args, **kwargs):
         return asyncio.ensure_future(self._coro_wrapper(func, *args, **kwargs))
 
-    @asyncio.coroutine
-    def _coro_wrapper(self, func, *args, **kwargs):
+    async def _coro_wrapper(self, func, *args, **kwargs):
         return func(*args, **kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ with open('HISTORY.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='anthunder',
-    version='0.6.3',
+    version='0.7',
     author='wanderxjtu',
     author_email='wanderhuang@gmail.com',
     url='https://github.com/alipay/sofa-bolt-python',


### PR DESCRIPTION
Migrates to `async def/await' syntax, drop support on python3.4.

Quote from [python doc](https://docs.python.org/3/library/asyncio-task.html#generator-based-coroutines)
> Generator-based Coroutines 
>... 
> *Deprecated since version 3.8, will be removed in version 3.10: Use async def instead.*