### PR TITLE
asyncio client same host use single connection

### DIFF
--- a/anthunder/client/aio_client.py
+++ b/anthunder/client/aio_client.py
@@ -55,6 +55,7 @@ class AioClient(_BaseClient):
         self.response_mapping = dict()  # request_id: response_pkg
         self.connection_mapping = dict()  # address: (reader_coro, writer)
         self.loop_thread = self._init()
+        self._pending_dial = dict()  # address: (asyncio.Lock)
 
     def _init(self):
         def _t():
@@ -143,9 +144,22 @@ class AioClient(_BaseClient):
 
     async def _get_connection(self, address):
         try:
-            reader, writer = await asyncio.open_connection(*address)
-            task = asyncio.ensure_future(self._recv_response(reader, writer))
-            return self.connection_mapping.setdefault(address, (task, writer))
+            # fast path return existed connection
+            ret = self.connection_mapping.get(address)
+            if ret:
+                return ret
+
+            lock = self._pending_dial.get(address)
+            if not lock:
+                lock = asyncio.Lock()
+                self._pending_dial[address] = lock
+            async with lock:
+                ret = self.connection_mapping.get(address)
+                if ret:
+                    return ret
+                reader, writer = await asyncio.open_connection(*address)
+                task = asyncio.ensure_future(self._recv_response(reader, writer))
+                return self.connection_mapping.setdefault(address, (task, writer))
         except Exception as e:
             logger.error("Get connection of {} failed: {}".format(address, e))
             raise
@@ -186,6 +200,7 @@ class AioClient(_BaseClient):
                 logger.error("Request sent to {} failed: {}, may try again.".format(address, e))
                 readtask.cancel()
                 self.connection_mapping.pop(address)
+                self._pending_dial.pop(address)
                 await _send(retry - 1)
 
         # generate event object first, ensure every successfully sent request has a event

--- a/anthunder/listener/aio_listener.py
+++ b/anthunder/listener/aio_listener.py
@@ -180,7 +180,7 @@ class AioListener(BaseListener):
             try:
                 try:
                     fixed_header_bs = await reader.readexactly(BoltRequest.bolt_header_size())
-                except asyncio.streams.IncompleteReadError:
+                except asyncio.IncompleteReadError:
                     if first_req:
                         # just connected, log an error
                         logging.error("Connection lost on first request")

--- a/tests/test_aio_listener_client.py
+++ b/tests/test_aio_listener_client.py
@@ -24,7 +24,6 @@ import logging
 from anthunder.command.heartbeat import HeartbeatRequest, HeartbeatResponse
 from anthunder.protocol.constants import RESPSTATUS
 
-
 if six.PY34:
     import asyncio
     import concurrent.futures
@@ -99,6 +98,11 @@ class TestListener(unittest.TestCase):
         for t in _ts:
             t.join()
 
+        for task in asyncio.all_tasks(client._loop):
+            print(task)
+        # _recv_response * 1
+        # _heartbeat_timer * 1
+        self.assertLessEqual(len(asyncio.all_tasks(client._loop)), 2)
         self.assertEqual(len(_result), 10)
         self.assertTrue(all(_result))
 


### PR DESCRIPTION
1. `asyncio.streams.IncompleteReadError` move to `asyncio.exceptions.IncompleteReadError` in Python3.9
2. one aioclient to same host use one connection
3. single flight dial in multi threading