### PR TITLE
drop python 2.7 support, bump version to anthunder 0.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/anthunder/__init__.py
+++ b/anthunder/__init__.py
@@ -22,7 +22,7 @@
         version0 : 2018/4/28 11:36 by jiaqi.hjq  init
 """
 
-__all__ = ['Client', 'SockListener', 'BaseService', 'Request', 'SERVICE_MAP']
+__all__ = ['Client', 'SockListener', 'BaseService', 'Request', 'SERVICE_MAP', 'AioListener', 'AioClient']
 
 from anthunder.helpers.immutable_dict import ImmutableValueDict
 
@@ -32,10 +32,5 @@ from anthunder.client.client import Client
 from anthunder.listener.sock_listener import SockListener
 from anthunder.listener.base_listener import BaseService
 from anthunder.request import Request
-import six
-
-if six.PY34:
-    __all__.extend(['AioListener', 'AioClient'])
-
-    from anthunder.listener.aio_listener import AioListener
-    from anthunder.client.aio_client import AioClient
+from anthunder.listener.aio_listener import AioListener
+from anthunder.client.aio_client import AioClient

--- a/anthunder/client/__init__.py
+++ b/anthunder/client/__init__.py
@@ -17,13 +17,7 @@
    File Name : __init__.py
    Author : jiaqi.hjq
 """
-__all__ = ["Client"]
+__all__ = ["Client", "AioClient",]
 
 from .client import Client
-
-import six
-
-if six.PY34:
-    from .aio_client import AioClient
-
-    __all__.append("AioClient")
+from .aio_client import AioClient

--- a/anthunder/helpers/request_id.py
+++ b/anthunder/helpers/request_id.py
@@ -20,7 +20,6 @@
 import logging
 from random import randint
 from itertools import cycle, chain
-from six.moves import range
 
 logger = logging.getLogger(__name__)
 

--- a/anthunder/listener/__init__.py
+++ b/anthunder/listener/__init__.py
@@ -19,14 +19,8 @@
 
 """
 
-__all__ = ['BaseService', 'SockListener']
+__all__ = ['BaseService', 'SockListener', 'AioListener']
 
 from .base_listener import BaseService
 from .sock_listener import SockListener
-
-import six
-
-if six.PY34:
-    from .aio_listener import AioListener
-
-    __all__.append('AioListener')
+from .aio_listener import AioListener

--- a/anthunder/listener/base_listener.py
+++ b/anthunder/listener/base_listener.py
@@ -27,6 +27,13 @@ logger = logging.getLogger(__name__)
 
 
 class BaseService(object):
+    """
+    Service classes provides service interfaces.
+    After registering to a interface, Listener will create a object of Service type on each request on this interface, 
+    and call to the method specified in request header with request body bytes.
+    The object is created with a spanctx as its first positional argument, such spanctx can than be referenced 
+    by self.ctx, and used in logging and/or passing to downstream in later rpc calling.
+    """
     def __init__(self, ctx):
         self.ctx = ctx
 

--- a/anthunder/listener/sock_listener.py
+++ b/anthunder/listener/sock_listener.py
@@ -21,7 +21,7 @@ import logging
 import traceback
 from errno import ECONNRESET
 
-from six.moves.socketserver import StreamRequestHandler, ThreadingTCPServer
+from socketserver import StreamRequestHandler, ThreadingTCPServer
 
 import opentracing
 from mytracer import tracer

--- a/anthunder/protocol/_sofa_header.py
+++ b/anthunder/protocol/_sofa_header.py
@@ -22,7 +22,6 @@
         version0 : 2018/5/17 14:04 by jiaqi.hjq  init
 """
 import struct
-import six
 from mytracer import SpanContext
 
 from ._rpc_trace_context import RpcTraceContext
@@ -48,7 +47,7 @@ def _str_to_bytes_with_len(s, coding='utf-8'):
     :param coding:
     :return: bytes object
     """
-    assert isinstance(s, six.string_types)
+    assert isinstance(s, str)
     b = s.encode(coding)
     return _int2bytes_be(len(b)) + b
 
@@ -106,7 +105,7 @@ class SofaHeader(dict):
 
     def to_bytes(self):
         try:
-            return b''.join(_str_to_bytes_with_len(k) + _str_to_bytes_with_len(v) for k, v in six.iteritems(self))
+            return b''.join(_str_to_bytes_with_len(k) + _str_to_bytes_with_len(v) for k, v in self.items())
         except AttributeError as e:  # pragma: no cover
             raise EncodeError(e)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ attrs>=18.1.0
 opentracing>=1.3.0
 requests-mock>=1.5.0
 protobuf>=3.5
-uvloop>=0.10.1; python_version >= '3.5'
+uvloop>=0.10.1 <0.15; python_version >= '3.5' < '3.7
+uvloop>=0.15; python_version >= '3.7'
 selectors34; python_version == '2.7'
 ipaddress; python_version == '2.7'
 mock; python_version == '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,3 @@ opentracing>=1.3.0
 requests-mock>=1.5.0
 protobuf>=3.5
 uvloop>=0.15; python_version >= '3.7'
-selectors34; python_version == '2.7'
-ipaddress; python_version == '2.7'
-mock; python_version == '2.7'
-enum34; python_version == '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ attrs>=18.1.0
 opentracing>=1.3.0
 requests-mock>=1.5.0
 protobuf>=3.5
-uvloop>=0.10.1 <0.15; python_version >= '3.5' < '3.7
 uvloop>=0.15; python_version >= '3.7'
 selectors34; python_version == '2.7'
 ipaddress; python_version == '2.7'

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ with open('HISTORY.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='anthunder',
-    version='0.7',
+    version='0.8',
     author='wanderxjtu',
     author_email='wanderhuang@gmail.com',
     url='https://github.com/alipay/sofa-bolt-python',

--- a/tests/test_aio_listener_client.py
+++ b/tests/test_aio_listener_client.py
@@ -18,38 +18,32 @@
    Author : jiaqi.hjq
 """
 import unittest
-import six
-import logging
 
 from anthunder.command.heartbeat import HeartbeatRequest, HeartbeatResponse
 from anthunder.protocol.constants import RESPSTATUS
 
-if six.PY34:
-    import asyncio
-    import concurrent.futures
-    import functools
-    import threading
-    import time
-    from unittest import mock
-    from random import randint
+import concurrent.futures
+import functools
+import threading
+import time
+from unittest import mock
+from random import randint
 
-    from mytracer import SpanContext
+from mytracer import SpanContext
 
-    from anthunder import AioClient
-    from anthunder.listener.aio_listener import AioListener
-    from anthunder.listener.base_listener import BaseService
-    from tests.proto.python import SampleService
-    from tests.proto.python.SampleServicePbRequest_pb2 import SampleServicePbRequest
-    from tests.proto.python.SampleServicePbResult_pb2 import SampleServicePbResult
-    try:
-        from asyncio import all_tasks
-    except ImportError:
-        from asyncio import Task
-        all_tasks = Task.all_tasks
+from anthunder import AioClient
+from anthunder.listener.aio_listener import AioListener
+from anthunder.listener.base_listener import BaseService
+from tests.proto.python import SampleService
+from tests.proto.python.SampleServicePbRequest_pb2 import SampleServicePbRequest
+from tests.proto.python.SampleServicePbResult_pb2 import SampleServicePbResult
+try:
+    from asyncio import all_tasks
+except ImportError:
+    from asyncio import Task
+    all_tasks = Task.all_tasks
 
 
-
-@unittest.skipUnless(six.PY34, "Aio-classes only support python>3.4")
 class TestListener(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Python 2.7 was officially drop support EOL for over a year. 
For better support new features indroduced in new python versions, python 2.7 support will be dropped from anthunder >= 0.8.
If you still need to run this package in python 2.7 environment for some reason, you can stay in anthunder==0.7, but no more features would be added on 0.7 serials